### PR TITLE
拡散反射コードの修正

### DIFF
--- a/main.c
+++ b/main.c
@@ -78,7 +78,7 @@ static t_vec3	ray_color(t_ray *r)
 	return (sky_blue(r->direction));
 }
 
-static void	ray_loop(t_ray *ray, t_vec3 *lower_left_corner, t_vec3 *horizontal, t_vec3 *vertical, t_img *img)
+static void	ray_loop(t_ray *ray, t_vec3 *vp_lower_left_corner, t_vec3 *horizontal, t_vec3 *vertical, t_img *img)
 {
 	double	i;
 	double	j;
@@ -99,7 +99,7 @@ static void	ray_loop(t_ray *ray, t_vec3 *lower_left_corner, t_vec3 *horizontal, 
 				mr_vec3_add(
 					mr_vec3_mul_double(*vertical, v), mr_vec3_mul_double(*horizontal, u)
 				),
-				*lower_left_corner
+				*vp_lower_left_corner
 			);
 			ray->direction = mr_vec3_sub(
 								ray_cross_screen, ray->origin
@@ -119,25 +119,30 @@ static void	ray(t_img *img)
 {
 	const double 	viewport_height = 2.0;
 	const double 	viewport_width = ASPECT_RATIO * viewport_height;
+	const double 	viewport_z = 0;
 	const double 	focal_length = 1.0;
 	t_vec3			horizontal; // ビューポート幅ベクトル
 	t_vec3			vertical; // ビューポート高さベクトル
-	t_vec3			lower_left_corner; // ビューポート左下隅
+	t_vec3			vp_lower_left_corner; // ビューポート左下隅
+	t_vec3			vp_center; // ビューポート中心
 	t_vec3			coordinate_origin; // 座標原点
 	t_ray			ray;
 
 	mr_vec3_init(&coordinate_origin, 0, 0, 0);
-	mr_vec3_init(&ray.origin, 0, 0, -focal_length);
-	mr_vec3_init(&horizontal, viewport_width, 0, 0);
-	mr_vec3_init(&vertical, 0, viewport_height, 0);
-	lower_left_corner = mr_vec3_sub(
+	vp_center = coordinate_origin;
+	vp_center.z = viewport_z;
+	ray.origin = vp_center;
+	ray.origin.z -= focal_length;
+	mr_vec3_init(&horizontal, viewport_width, 0, viewport_z);
+	mr_vec3_init(&vertical, 0, viewport_height, viewport_z);
+	vp_lower_left_corner = mr_vec3_sub(
 		mr_vec3_sub(
-			coordinate_origin, mr_vec3_div_double(horizontal, 2)
+			vp_center, mr_vec3_div_double(horizontal, 2)
 		),
 		mr_vec3_div_double(vertical, 2)
 	);
-	// lower_left_corner.z -= focal_length;
-	ray_loop(&ray, &lower_left_corner, &horizontal, &vertical, img);
+	// vp_lower_left_corner.z -= focal_length;
+	ray_loop(&ray, &vp_lower_left_corner, &horizontal, &vertical, img);
 }
 
 int main()


### PR DESCRIPTION
## 修正内容

結論から言うと、衝突判定と法線ベクトルの計算は正しかったです。

- `lower_left_corner`のz座標を0のままにした
- 変数`coordinate_origin`を新設
- カメラをz < 0, 球をz > 0 に置いた
- 球とレイがビューポート上(z = 0)で衝突しないよう、球の中心と半径を調整した
- 色ベクトルの成分がマイナスになっていたので、絶対値(fabs)を取るようにした

## 変数の役割について

- `coordinate_origin`
  - **座標系の**原点を表す位置ベクトル
  - つまり`(x, y, z) = (0, 0, 0)`.
- `vp_center`
  - ビューポートの中心を表す位置ベクトル
  - これも`(x, y, z) = (0, 0, 0)`.
- `vp_lower_left_corner`
  - ビューポートの左下隅を表す位置ベクトル
  - ビューポートの高さをH, 幅をWとすると、`(x, y, z) = (-W/2, -H/2, 0)`
- `ray.origin`
  - レイの原点、つまりカメラ位置を表す位置ベクトル
  - 焦点距離をFとすると、`(x, y, z) = (0, 0, -F)`
- `horizontal`
- `vertical`
  - ビューポートの幅・高さと同じ長さを持つ**変位**ベクトル。
  - それぞれ`(W, 0, 0), (0, H, 0)`

## 位置ベクトルと変位ベクトル

- 2つの点の相対位置を表すベクトルを**変位**ベクトル(`displacement vector`)
- 原点からの位置(=絶対位置)を表すベクトルを**位置**ベクトル(`position vector`)

として区別して考えると便利なことが多い。
大雑把に言うと、

- 変位ベクトルと変位ベクトルを足したものは変位ベクトル
- 位置ベクトルと変位ベクトルを足したものは位置ベクトル
- 位置ベクトルから位置ベクトルを引いたものは変位ベクトル
- 位置ベクトルと位置ベクトルを足すときは意味をよく考えること


