### PR TITLE
bugfix: 円錐のヒット判定がバグっている

### DIFF
--- a/srcs/rt_diffuse.c
+++ b/srcs/rt_diffuse.c
@@ -6,7 +6,7 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/12/22 22:03:25 by rmatsuka          #+#    #+#             */
-/*   Updated: 2021/12/31 18:40:12 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/01/04 18:30:02 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,8 +28,9 @@ t_vec3	rt_diffuse(
 	const t_vec3 *light_color)
 {
 	double	x;
-	t_vec3	color = *light_color;
+	t_vec3	color;
 
+	color = *light_color;
 	x = intensity(rec, light);
 	color = mr_vec3_product(*light_color, rec->color);
 	return (mr_vec3_mul_double(&color, x));

--- a/srcs/rt_equation.c
+++ b/srcs/rt_equation.c
@@ -6,7 +6,7 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/12/25 17:01:33 by corvvs            #+#    #+#             */
-/*   Updated: 2021/12/25 17:19:02 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/01/04 21:15:16 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,8 +38,16 @@ int	rt_solve_equation2(t_equation2 *arg)
 	else
 	{
 		arg->solutions = 2;
-		arg->t1 = (-arg->b_half - sqrt(discriminant)) / arg->a;
-		arg->t2 = (-arg->b_half + sqrt(discriminant)) / arg->a;
+		if (arg->a > 0)
+		{
+			arg->t1 = (-arg->b_half - sqrt(discriminant)) / arg->a;
+			arg->t2 = (-arg->b_half + sqrt(discriminant)) / arg->a;
+		}
+		else
+		{
+			arg->t2 = (-arg->b_half - sqrt(discriminant)) / arg->a;
+			arg->t1 = (-arg->b_half + sqrt(discriminant)) / arg->a;
+		}
 	}
 	return (arg->solutions);
 }

--- a/srcs/rt_texture_cone.c
+++ b/srcs/rt_texture_cone.c
@@ -6,7 +6,7 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/12/26 23:37:49 by corvvs            #+#    #+#             */
-/*   Updated: 2022/01/03 23:37:06 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/01/04 13:41:12 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,7 +20,7 @@ static void set_tangent_coordinate_cone(t_hit_record *rec)
 	const double	dx = mr_vec3_dot(pc, u1);
 	const double	dz = mr_vec3_dot(pc, u2);
 
-	rec->u = atan2(dz, dx);
+	rec->u = (1 - atan2(dz, dx)) / (2 * M_PI) - 0.5;
 	rec->v = mr_vec3_length(&pc);
 }
 

--- a/srcs/rt_texture_cylinder.c
+++ b/srcs/rt_texture_cylinder.c
@@ -6,7 +6,7 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/12/21 13:41:07 by rmatsuka          #+#    #+#             */
-/*   Updated: 2022/01/03 23:37:03 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/01/04 13:39:59 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,11 +15,15 @@
 static void set_tangent_coordinate_cylinder(t_hit_record *rec)
 {
 	const t_vec3	pc = mr_vec3_sub(rec->p, rec->element.position);
-	const t_vec3	u0 = rt_coord_perpendicular_unit(&rec->element.direction);
 	const t_vec3	v0 = rec->element.direction;
+	const t_vec3	w0 = rt_coord_perpendicular_unit(&v0);
+	const t_vec3	u0 = rt_coord_turn_around_90(&w0, &v0);
 
-	rec->u = mr_vec3_dot(pc, u0);
-	rec->v = mr_vec3_dot(pc, v0);
+	rec->u = 1 - (atan2(
+			mr_vec3_dot(pc, w0),
+			mr_vec3_dot(pc, u0)
+		) / (2 * M_PI) - 0.5);
+	rec->v = -mr_vec3_dot(pc, v0);
 }
 
 void	rt_set_tangent_cylinder(
@@ -36,8 +40,8 @@ void	rt_set_tangent_cylinder(
 	rec->normal = mr_vec3_sub(rec->p, axial_center);
 	rec->normal = mr_unit_vector(&rec->normal);
 	rec->w0 = rec->normal;
-	rec->u0 = rec->element.direction;
-	rec->v0 = mr_vec3_cross(&rec->w0, &rec->u0);
+	rec->v0 = rec->element.direction;
+	rec->u0 = mr_vec3_cross(&rec->v0, &rec->w0);
 	if (rec->element.bump_el || rec->element.tex_el)
 		set_tangent_coordinate_cylinder(rec);
 }


### PR DESCRIPTION
2次方程式 `at^2 + 2tb + c = 0`の実数解は最大2つある:

```
t1 = (-b - √(b^2 - ac)) / a
t2 = (-b + √(b^2 - ac)) / a
```

これらの解に対して、`t1 <= t2`という仮定をしていたことがバグの原因。
実際には、`a < 0`ならば`t1 >= t2`となってしまう。