### PR TITLE
bugfix: 円柱の縁に光源がうまっているとグリッチが発生する

### DIFF
--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/12/08 19:00:14 by corvvs            #+#    #+#             */
-/*   Updated: 2022/01/02 18:19:36 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/01/04 13:54:25 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -64,11 +64,12 @@ static t_vec3	light_proc(
 )
 {
 	t_vec3	base_color;
+	t_vec3	light_color;
 
 	mr_vec3_init(&base_color, 0, 0, 0);
 	if (actual->hit && !rt_is_shadow(actual, light, scene, r))
 	{
-		t_vec3	light_color = mr_vec3_mul_double(&light->color, light->ratio);
+		light_color = mr_vec3_mul_double(&light->color, light->ratio);
 		base_color = mr_vec3_add(base_color, rt_diffuse(actual, light, &light_color));
 		base_color = mr_vec3_add(base_color, rt_specular(actual, &light->position, &light_color, r));
 	}
@@ -150,6 +151,8 @@ static void	ray_loop(
 	double	i;
 	double	j;
 	t_ray	ray;
+
+	ray.for_shadow = false;
 	scene->recs = (t_hit_record *)malloc(scene->n_objects * sizeof(t_hit_record));
 
 	j = 0;

--- a/srcs/rt_is_shadow.c
+++ b/srcs/rt_is_shadow.c
@@ -6,12 +6,13 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/12/09 16:56:38 by rmatsuka          #+#    #+#             */
-/*   Updated: 2021/12/27 00:18:14 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/01/04 13:57:18 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minirt.h"
-#define EPS 1e-6
+#define EPS 1e-5
+#define EPS2 1e-2
 
 // 光源とカメラが反射面を挟んで逆側にいる時反射は起きない
 static bool	is_reflective_part(
@@ -25,24 +26,15 @@ static bool	is_reflective_part(
 	const double	cos_ray = mr_vec3_dot(
 						ray->direction, rec->normal);
 	const bool is_reflective = (cos_light > 0 && cos_ray > 0) || (cos_light < 0 && cos_ray < 0);
+
 	if (!is_reflective)
-	{
-		// printf("NL: %f %f (%d, %d)\n", cos_light, cos_ray, ray->pixel_x, ray->pixel_y);
-		// vec3_debug((t_vec3 *)&rec->p);
-		// vec3_debug((t_vec3 *)&rec->normal);
 		return (false);
-	}
-	if (light->etype == RD_ET_SPOTLIGHT)
-	{
-		// [スポットライトの場合]
-		// normalize(反射点 - ライト位置)・ライト方位 > cos(FOV/2)ならばfalse
-		t_vec3 pc = mr_vec3_sub(rec->p, light->position);
-		pc = mr_unit_vector(&pc);
-		const double cs = mr_vec3_dot(pc, light->direction);
-		if (cs < cos(light->fov * M_PI / 360))
-			return (false);
-	}
-	return (true);
+	if (light->etype != RD_ET_SPOTLIGHT)
+		return (true);
+	t_vec3 pc = mr_vec3_sub(rec->p, light->position);
+	pc = mr_unit_vector(&pc);
+	const double cs = mr_vec3_dot(pc, light->direction);
+	return (cs >= cos(light->fov * M_PI / 360));
 }
 
 bool	rt_is_shadow(
@@ -57,27 +49,27 @@ bool	rt_is_shadow(
 		ray->marking_color = (t_vec3){0,0,1};
 		return (true);
 	}
-	t_ray	shadow_ray;
-	const t_vec3 v = mr_vec3_sub(*light_pos, actual->p); // 交点から光源へのベクトル
-	const t_vec3 incident = mr_unit_vector(&v); // 出射ベクトル
+	const t_vec3	v = mr_vec3_sub(*light_pos, actual->p); // 交点から光源へのベクトル
+	const t_vec3	incident = mr_unit_vector(&v); // 出射ベクトル
+	const double	dist_to_light = mr_vec3_length(&v);
+	t_ray			shadow_ray;
+	size_t			i;
+
 	shadow_ray.origin = mr_vec3_add(actual->p, mr_vec3_mul_double(&incident, EPS - 1)); // 入射方向に少しずらす
 	shadow_ray.direction = incident;
-	size_t i = 0;
-
-	// 光源までの距離
-	double dist_to_light = mr_vec3_length(&v) - EPS;
-
+	shadow_ray.for_shadow = true;
 	ft_bzero(scene->recs, scene->n_objects * sizeof(t_hit_record));
+	i = 0;
 	while (i < scene->n_objects)
 	{
 		if (rt_hit_object(scene->objects[i], &shadow_ray, &scene->recs[i]))
 		{
-			t_vec3 normal = shadow_ray.direction;
-			t_vec3 tmp = mr_vec3_mul_double(&normal, scene->recs[i].t); // シャドウレイからt倍する
-			double dist_to_obj = mr_vec3_length(&tmp) - 1;
-			if (dist_to_obj < dist_to_light)  // 物体との距離が光源よりも近い場合
+			double dist_to_obj = scene->recs[i].t - 1 + EPS;
+			if (dist_to_obj < dist_to_light || fabs(dist_to_obj - dist_to_light) < EPS)  // 物体との距離が光源よりも近い場合
 			{
-				ray->marking_color = (t_vec3){0,1,1};
+				printf("%f - %f ", dist_to_obj, dist_to_light);
+				vec3_debug((t_vec3 *)&actual->p);
+				ray->marking_color = (t_vec3){1,0,1};
 				return (true);
 			}
 		}

--- a/srcs/rt_object_cylinder.c
+++ b/srcs/rt_object_cylinder.c
@@ -23,7 +23,7 @@ static bool	hit_at(
 	double axial_displacement = mr_vec3_dot(
 		mr_vec3_sub(rec->p, el->position), el->direction
 	);
-	if (t < 1 || fabs(axial_displacement) >= el->height / 2)
+	if (t < 1 || fabs(axial_displacement) >= ((el->height + (ray->for_shadow ? 1e-6 : 0)) / 2))
 		rec->hit = false;
 	else
 	{


### PR DESCRIPTION
シャドウレイと円柱が衝突すべきところで衝突しないことがある。
これは円柱が「開いた」立体であることが原因。

確認用RTファイル
```
A 0.2   100,100,200
L 0,4,0 1.0 200,0,0
cy 0,0,5 0,0,1 8 10 200,200,200
C 0,0,-8 0,0,1 90
```

### before
![image](https://user-images.githubusercontent.com/10496148/148062281-824dfddb-b098-4ecd-91dc-b5519e4d483d.png)

### after

![image](https://user-images.githubusercontent.com/10496148/148062331-b427ee81-44b2-44bf-904a-18eeb55e01fb.png)
