### PR TITLE
各種微妙な例の修正

### DIFF
--- a/rd/rd_after_extraction.c
+++ b/rd/rd_after_extraction.c
@@ -6,7 +6,7 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/01/07 20:59:37 by corvvs            #+#    #+#             */
-/*   Updated: 2022/01/08 10:35:04 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/01/08 17:35:13 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,6 +37,8 @@ void	rt_after_extraction(t_element *el)
 	el->direction = mr_vec3_mul_double(&el->direction, 1 / r);
 	el->color = mr_vec3_mul_double(&el->color, 1 / 255.0);
 	el->subcolor = mr_vec3_mul_double(&el->subcolor, 1 / 255.0);
+	if (el->etype == RD_ET_CONE && fabs(el->fov - 180) < 1e-6)
+		el->etype = RD_ET_PLANE;
 	el->fov *= M_PI / 360;
 	if (el->etype == RD_ET_PARABOLOID)
 		after_extraction_paraboloid(el);

--- a/srcs/rt_diffuse.c
+++ b/srcs/rt_diffuse.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   rt_diffuse.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: rmatsuka < rmatsuka@student.42tokyo.jp>    +#+  +:+       +#+        */
+/*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/12/22 22:03:25 by rmatsuka          #+#    #+#             */
-/*   Updated: 2022/01/05 00:24:15 by rmatsuka         ###   ########.fr       */
+/*   Updated: 2022/01/08 18:01:05 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,7 +21,7 @@ static double	intensity(
 						mr_unit_vector(&light_in), rec->normal);
 
 	return (fabs(cos_light / \
-			pow(LIGHT_DISTANCE_DECAY * mr_vec3_length_squared(&light_in), 1)));
+			(LIGHT_DISTANCE_DECAY * mr_vec3_length_squared(&light_in))));
 }
 
 t_vec3	rt_diffuse(

--- a/srcs/rt_hit_util.c
+++ b/srcs/rt_hit_util.c
@@ -60,9 +60,9 @@ bool	rt_hit_object(
 	const t_object_hit_tester	hit_tester = g_hit_testers[el->etype];
 
 	rec->hit = false;
-	if (hit_tester)
-		return (hit_tester(el, ray, rec));
-	return (false);
+	if (!hit_tester)
+		return (false);
+	return (hit_tester(el, ray, rec));
 }
 
 t_hit_record	*rt_find_actual_hit(t_ray *r, t_scene *scene)

--- a/srcs/rt_is_shadow.c
+++ b/srcs/rt_is_shadow.c
@@ -52,8 +52,7 @@ static bool	is_obj_closer_than_light(
 		if (rt_hit_object(scene->objects[i], shadow_ray, &scene->recs[i]))
 		{
 			dist_to_obj = scene->recs[i].t - 1 + EPS;
-			if (dist_to_obj < dist_to_light ||
-				fabs(dist_to_obj - dist_to_light) < EPS)
+			if (dist_to_obj < dist_to_light)
 			{
 				return (true);
 			}

--- a/srcs/rt_is_shadow.c
+++ b/srcs/rt_is_shadow.c
@@ -6,7 +6,7 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/12/09 16:56:38 by rmatsuka          #+#    #+#             */
-/*   Updated: 2022/01/09 20:12:11 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/01/09 20:36:18 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,7 +52,8 @@ static bool	is_obj_closer_than_light(
 		if (rt_hit_object(scene->objects[i], shadow_ray, &scene->recs[i]))
 		{
 			dist_to_obj = scene->recs[i].t - 1 + EPS;
-			if (fabs(dist_to_obj - dist_to_light) < EPS)
+			if (dist_to_obj < dist_to_light ||
+				fabs(dist_to_obj - dist_to_light) < EPS)
 			{
 				return (true);
 			}

--- a/srcs/rt_is_shadow.c
+++ b/srcs/rt_is_shadow.c
@@ -6,7 +6,7 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/12/09 16:56:38 by rmatsuka          #+#    #+#             */
-/*   Updated: 2022/01/08 16:15:43 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/01/09 20:12:11 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,8 +52,7 @@ static bool	is_obj_closer_than_light(
 		if (rt_hit_object(scene->objects[i], shadow_ray, &scene->recs[i]))
 		{
 			dist_to_obj = scene->recs[i].t - 1 + EPS;
-			if (dist_to_obj < dist_to_light \
-				|| fabs(dist_to_obj - dist_to_light) < EPS)
+			if (fabs(dist_to_obj - dist_to_light) < EPS)
 			{
 				return (true);
 			}
@@ -74,8 +73,8 @@ bool	rt_is_shadow(
 	t_ray *ray)
 {
 	const t_vec3	v = mr_vec3_sub(light->position, actual->p);
-	const t_vec3	incident = mr_unit_vector(&v);
-	const double	dist_to_light = mr_vec3_length(&v);
+	const t_vec3	incident = mr_vec3_mul_double(&v, 1);
+	const double	dist_to_light = 1;
 	t_ray			shadow_ray;
 
 	if (!is_reflective_part(actual, light, ray))

--- a/srcs/rt_specular.c
+++ b/srcs/rt_specular.c
@@ -3,18 +3,18 @@
 /*                                                        :::      ::::::::   */
 /*   rt_specular.c                                      :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: rmatsuka < rmatsuka@student.42tokyo.jp>    +#+  +:+       +#+        */
+/*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/12/22 22:54:35 by rmatsuka          #+#    #+#             */
-/*   Updated: 2022/01/05 12:05:48 by rmatsuka         ###   ########.fr       */
+/*   Updated: 2022/01/09 22:32:34 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minirt.h"
 
-#define COEF 0.3f
-#define INTENSITY 1.0f
-#define GLOSS 30.0f
+#define COEF 0.3
+#define INTENSITY 100.0
+#define GLOSS 30.0
 
 // ray_inverse = レイの方向の逆向きの方向ベクトル(正規化済み)
 // light_out = 反射面から光源を見る方向ベクトル
@@ -26,15 +26,16 @@ t_vec3	rt_specular(
 	const t_ray *ray)
 {
 	const t_vec3	temp2 = mr_vec3_sub(*light, rec->p);
-	const t_vec3	light_out = mr_unit_vector(&temp2);
-	const t_vec3	reflect_of_light = mr_vec3_sub(
+	const t_vec3	surface_to_light = mr_unit_vector(&temp2);
+	const t_vec3	surface_to_reflection = mr_vec3_sub(
+						surface_to_light,
 						mr_vec3_mul_double(
-						&rec->normal, mr_vec3_dot(rec->normal, light_out) * 2
-						),
-						light_out
+						&rec->normal,
+						mr_vec3_dot(rec->normal, surface_to_light) * 2
+						)
 					);
-	const double	rr = -mr_vec3_dot(
-				mr_unit_vector(&ray->direction), reflect_of_light);
+	const double	rr = mr_vec3_dot(
+				mr_unit_vector(&ray->direction), surface_to_reflection);
 	t_vec3			color;
 
 	if (rr < 0)
@@ -44,5 +45,6 @@ t_vec3	rt_specular(
 	color = mr_vec3_product(*light_color, rec->color);
 	return (mr_vec3_mul_double(
 			&color,
-			(COEF * INTENSITY * pow(rr, GLOSS))));
+			(COEF * INTENSITY
+				* pow(rr, GLOSS) / mr_vec3_length_squared(&temp2))));
 }


### PR DESCRIPTION
## チェック項目(TODO)

## 修正済内容

### (1) 開き角180度の円錐を平面に変換する 

円錐のFOVパラメータを180度にすると、数学的にはこれはただの平面となる。
これを円錐として各種処理を行うと色々バグるので、実際に平面にしてしまう。

### (2) シャドウレイの`direction`の大きさを、「反射点から光源までのベクトルの長さ」と同じにする。

従来、シャドウレイの`direction`の大きさは1だったが、これだと座標が巨大なときに不具合が起こっていた。

とはいえ、これは不具合を完全に防ぐわけではない。
が、精度は有限である以上、精度に由来する不具合を完全に防ぐのは難しいと考えられる。

### (3) 円錐の先端から光がもれている

円錐の中に点光源を置いて円錐の外部にカメラを置くと、光源を置いた方と逆側の円錐の表面が照らされてしまう。

-> (2)対応時に入ったバグだった。修正。

```
A  0.2      100,100,200
L  0,-5,0  0.8         255,0,0
C  0,0,-10 0,0,1 90
co 0,0,0 0,1,0 90 255,255,255
```

![image](https://user-images.githubusercontent.com/10496148/148680093-6d630528-f675-439e-bd18-908117eb8057.png)

### (4) 鏡面反射に距離減衰を導入

鏡面反射には距離減衰がなかったが、光源から反射面に当たるまでの距離減衰は考慮が必要(miniRTには点光源しかないため)。

