### PR TITLE
bugfix: チェッカーの模様がずれる

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ SRCS		:=	debug.c \
 				rt_specular.c \
 				rt_coord_util.c \
 				rt_equation.c \
-				rt_bumpfunc.c
+				rt_bumpfunc.c \
+				rt_fmath.c
 
 
 OBJS		=	$(addprefix $(OBJDIR), $(SRCS:.c=.o))

--- a/includes/minirt.h
+++ b/includes/minirt.h
@@ -6,7 +6,7 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/01/07 19:38:27 by corvvs            #+#    #+#             */
-/*   Updated: 2022/01/12 01:35:11 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/01/12 03:57:38 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -112,6 +112,9 @@ bool			rt_is_shadowed_from(
 					const t_element *light,
 					t_scene *scene,
 					t_ray *ray);
+
+double			rt_fmod(double x, double y);
+double			rt_floor(double x);
 
 /* debug */
 void			vec3_debug(const t_vec3 *vec);

--- a/includes/minirt.h
+++ b/includes/minirt.h
@@ -6,7 +6,7 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/01/07 19:38:27 by corvvs            #+#    #+#             */
-/*   Updated: 2022/01/08 16:57:03 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/01/12 01:35:11 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,8 +36,16 @@
 /* keycode */
 # ifdef __linux__
 #  define KEY_ESC 65307
+#  define EVENT_KEY_PRESS 2
+#  define MASK_KEY_PRESS 1L
+#  define EVENT_CLOSE 17
+#  define MASK_CLOSE 131072L
 # else
-#  define KEY_ESC 53
+#  define KEY_ESC 65307
+#  define EVENT_KEY_PRESS 2
+#  define MASK_KEY_PRESS 1L
+#  define EVENT_CLOSE 17
+#  define MASK_CLOSE 131072L
 # endif
 
 /* colorcode */
@@ -54,6 +62,7 @@ void			mr_bailout(t_info *info, const char *error);
 void			mr_mlx_pixel_put(t_img *img, int x, int y, const t_vec3 v3);
 unsigned int	mr_mlx_pixel_get(t_img *img, int x, int y);
 int				mr_exit_window(t_info *info);
+int				mr_hook_key_press(int key, t_info *info);
 bool			mr_read_image_files(t_info *info);
 void			mr_destroy_image_files(t_info *info);
 

--- a/includes/minirt.h
+++ b/includes/minirt.h
@@ -67,9 +67,7 @@ bool			mr_read_image_files(t_info *info);
 void			mr_destroy_image_files(t_info *info);
 
 int				rt_create_trgb(int t, int r, int g, int b);
-t_vec3			rt_color_at(t_img *image, int x, int y);
-double			rt_grayscale_color_at(t_img *image, int x, int y);
-t_vec3			rt_element_color(double u, double v, t_element *el);
+t_vec3			rt_color_texture(double u, double v, t_element *el);
 
 void			rt_raytrace(t_info *info, t_scene *scene);
 
@@ -93,23 +91,23 @@ t_vec3			rt_reflect_ray(
 					t_scene *scene,
 					t_hit_record *actual);
 
-t_vec3			rt_ambient(
+t_vec3			rt_color_ambient(
 					const double ratio,
 					const t_vec3 *ambient_color,
 					const t_vec3 *obj_color);
 
-t_vec3			rt_diffuse(
+t_vec3			rt_color_diffuse(
 					const t_hit_record *rec,
 					const t_element *light,
 					const t_vec3 *light_color);
 
-t_vec3			rt_specular(
+t_vec3			rt_color_specular(
 					const t_hit_record *rec,
 					const t_vec3 *light,
 					const t_vec3 *light_color,
 					const t_ray *ray);
 
-bool			rt_is_shadow(
+bool			rt_is_shadowed_from(
 					const t_hit_record *actual,
 					const t_element *light,
 					t_scene *scene,

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/12/08 19:00:14 by corvvs            #+#    #+#             */
-/*   Updated: 2022/01/11 18:58:14 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/01/12 00:53:28 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -70,7 +70,10 @@ int	main(int argc, char **argv)
 	setup(argc, argv, &info);
 	rt_raytrace(&info, &scene);
 	mlx_put_image_to_window(info.mlx, info.win, info.img.img, 0, 0);
-	mlx_hook(info.win, 17, 1L << 17, &mr_exit_window, &info);
+	mlx_hook(info.win,
+		EVENT_CLOSE, MASK_CLOSE, &mr_exit_window, &info);
+	mlx_hook(info.win,
+		EVENT_KEY_PRESS, MASK_KEY_PRESS, &mr_hook_key_press, &info);
 	mlx_loop(info.mlx);
 	return (0);
 }

--- a/srcs/mr_mlx_utils.c
+++ b/srcs/mr_mlx_utils.c
@@ -6,16 +6,23 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/01/04 23:43:35 by rmatsuka          #+#    #+#             */
-/*   Updated: 2022/01/12 01:35:51 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/01/12 02:46:32 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minirt.h"
 
+#define SHIFT_T 24
+#define SHIFT_R 16
+#define SHIFT_G 8
+#define SHIFT_B 0
+
 static int	vec3_to_color(const t_vec3 *v3)
 {
-	return (rt_create_trgb(0,
-			(int)(v3->x * 255), (int)(v3->y * 255), (int)(v3->z * 255)));
+	return ((0 << SHIFT_T)
+		| ((int)(v3->x * 255) << SHIFT_R)
+			| ((int)(v3->y * 255) << SHIFT_G)
+			| ((int)(v3->z * 255) << SHIFT_B));
 }
 
 void	mr_mlx_pixel_put(t_img *img, int x, int y, const t_vec3 v3)

--- a/srcs/mr_mlx_utils.c
+++ b/srcs/mr_mlx_utils.c
@@ -6,7 +6,7 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/01/04 23:43:35 by rmatsuka          #+#    #+#             */
-/*   Updated: 2022/01/11 18:56:57 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/01/12 01:35:51 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,5 +41,12 @@ int	mr_exit_window(t_info *info)
 	mlx_destroy_window(info->mlx, info->win);
 	mlx_destroy_display(info->mlx);
 	exit(0);
+	return (0);
+}
+
+int	mr_hook_key_press(int key, t_info *info)
+{
+	if (key == KEY_ESC)
+		mr_exit_window(info);
 	return (0);
 }

--- a/srcs/mr_mlx_utils.c
+++ b/srcs/mr_mlx_utils.c
@@ -47,6 +47,7 @@ int	mr_exit_window(t_info *info)
 	rd_destroy_scene(info->scene);
 	mlx_destroy_window(info->mlx, info->win);
 	mlx_destroy_display(info->mlx);
+	ft_malloc_balance();
 	exit(0);
 	return (0);
 }

--- a/srcs/mr_reading_imagefile.c
+++ b/srcs/mr_reading_imagefile.c
@@ -6,7 +6,7 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/01/07 22:47:00 by corvvs            #+#    #+#             */
-/*   Updated: 2022/01/11 18:58:14 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/01/12 02:52:50 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,6 +48,7 @@ static bool	read_xmp_image(t_info *info, t_element *el)
 	return (!!image->addr);
 }
 
+// destroy all (loaded) images for texture / bumpmap elements.
 void	mr_destroy_image_files(t_info *info)
 {
 	t_element	**objects;
@@ -77,6 +78,8 @@ void	mr_destroy_image_files(t_info *info)
 	}
 }
 
+// for all texture or bumpmap elements,
+// read images from attached xpm_file_path.
 bool	mr_read_image_files(t_info *info)
 {
 	t_element	**objects;

--- a/srcs/rt_ambient.c
+++ b/srcs/rt_ambient.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   rt_ambient.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: rmatsuka < rmatsuka@student.42tokyo.jp>    +#+  +:+       +#+        */
+/*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/12/22 23:28:57 by rmatsuka          #+#    #+#             */
-/*   Updated: 2021/12/22 23:30:01 by rmatsuka         ###   ########.fr       */
+/*   Updated: 2022/01/12 02:31:40 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,7 +22,8 @@ static t_vec3	mr_vec3_mul(const t_vec3 *u, const t_vec3 *v)
 	return (mul);
 }
 
-t_vec3	rt_ambient(
+// color component by ambient light.
+t_vec3	rt_color_ambient(
 	const double ratio,
 	const t_vec3 *ambient_color,
 	const t_vec3 *obj_color)

--- a/srcs/rt_bumpfunc.c
+++ b/srcs/rt_bumpfunc.c
@@ -6,7 +6,7 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/12/27 02:22:27 by corvvs            #+#    #+#             */
-/*   Updated: 2022/01/12 02:38:31 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/01/12 04:29:39 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,10 +48,8 @@ static	void	uv_normal(
 
 t_vec3	rt_bumpnormal(double u, double v, t_img *bumpmap)
 {
-	const double	jd = fmod(u * bumpmap->width + 100000 * bumpmap->width,
-		bumpmap->width);
-	const double	id = fmod(v * bumpmap->height + 100000 * bumpmap->height,
-		bumpmap->height);
+	const double	jd = rt_fmod(u * bumpmap->width, bumpmap->width);
+	const double	id = rt_fmod(v * bumpmap->height, bumpmap->height);
 	t_vec3			n;
 	double			norm;
 

--- a/srcs/rt_bumpfunc.c
+++ b/srcs/rt_bumpfunc.c
@@ -6,13 +6,22 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/12/27 02:22:27 by corvvs            #+#    #+#             */
-/*   Updated: 2022/01/07 20:42:51 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/01/12 02:38:31 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minirt.h"
-#define IMAGE_W 6
-#define IMAGE_H 6
+
+static double	grayscale_color_at(
+	t_img *image,
+	int x,
+	int y
+)
+{
+	const unsigned int	color = mr_mlx_pixel_get(image, x, y);
+
+	return ((color & 0xff) / 255.0);
+}
 
 static	void	uv_normal(
 	t_vec3 *n,
@@ -21,14 +30,14 @@ static	void	uv_normal(
 	double j
 )
 {
-	const double	h1 = rt_grayscale_color_at(bumpmap,
+	const double	h1 = grayscale_color_at(bumpmap,
 						(int)j, (int)i);
-	const double	h2 = rt_grayscale_color_at(bumpmap,
+	const double	h2 = grayscale_color_at(bumpmap,
 						(int)(j + 1) % bumpmap->width,
 						(int)i);
-	const double	h3 = rt_grayscale_color_at(bumpmap,
+	const double	h3 = grayscale_color_at(bumpmap,
 						(int)j, (int)(i + 1) % bumpmap->height);
-	const double	h4 = rt_grayscale_color_at(bumpmap,
+	const double	h4 = grayscale_color_at(bumpmap,
 						(int)(j + 1) % bumpmap->width,
 						(int)(i + 1) % bumpmap->height);
 	const double	c = 2;

--- a/srcs/rt_color.c
+++ b/srcs/rt_color.c
@@ -6,7 +6,7 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/01/05 00:01:16 by rmatsuka          #+#    #+#             */
-/*   Updated: 2022/01/12 02:56:53 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/01/12 04:30:32 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,9 +33,7 @@ t_vec3	rt_color_texture(double u, double v, t_element *el)
 	double		id;
 
 	texture = el->image;
-	jd = fmod(u * texture->width * el->freq_u + \
-			100000 * texture->width, texture->width);
-	id = fmod(v * texture->height * el->freq_v + \
-			100000 * texture->height, texture->height);
+	jd = rt_fmod(u * texture->width * el->freq_u, texture->width);
+	id = rt_fmod(v * texture->height * el->freq_v, texture->height);
 	return (color_at((t_img *)texture, jd, id));
 }

--- a/srcs/rt_color.c
+++ b/srcs/rt_color.c
@@ -6,23 +6,13 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/01/05 00:01:16 by rmatsuka          #+#    #+#             */
-/*   Updated: 2022/01/07 20:33:37 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/01/12 02:56:53 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minirt.h"
 
-#define SHIFT_T 24
-#define SHIFT_R 16
-#define SHIFT_G 8
-#define SHIFT_B 0
-
-int	rt_create_trgb(int t, int r, int g, int b)
-{
-	return (t << SHIFT_T | r << SHIFT_R | g << SHIFT_G | b);
-}
-
-t_vec3	rt_color_at(
+static t_vec3	color_at(
 	t_img *image,
 	int x, int y
 )
@@ -36,31 +26,16 @@ t_vec3	rt_color_at(
 	return (cv);
 }
 
-double	rt_grayscale_color_at(
-	t_img *image,
-	int x,
-	int y
-)
-{
-	const unsigned int	color = mr_mlx_pixel_get(image, x, y);
-
-	return ((color & 0xff) / 255.0);
-}
-
-t_vec3	rt_element_color(double u, double v, t_element *el)
+t_vec3	rt_color_texture(double u, double v, t_element *el)
 {
 	t_img		*texture;
 	double		jd;
 	double		id;
-	int			ji;
-	int			ii;
 
 	texture = el->image;
 	jd = fmod(u * texture->width * el->freq_u + \
 			100000 * texture->width, texture->width);
 	id = fmod(v * texture->height * el->freq_v + \
 			100000 * texture->height, texture->height);
-	ji = jd;
-	ii = id;
-	return (rt_color_at((t_img *)texture, ji, ii));
+	return (color_at((t_img *)texture, jd, id));
 }

--- a/srcs/rt_coord_util.c
+++ b/srcs/rt_coord_util.c
@@ -3,17 +3,18 @@
 /*                                                        :::      ::::::::   */
 /*   rt_coord_util.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: rmatsuka < rmatsuka@student.42tokyo.jp>    +#+  +:+       +#+        */
+/*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/12/24 17:56:27 by corvvs            #+#    #+#             */
-/*   Updated: 2022/01/05 11:48:09 by rmatsuka         ###   ########.fr       */
+/*   Updated: 2022/01/12 02:08:49 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minirt.h"
 #define EPS 1e-6
 
-// 与えられた単位ベクトル u について、それに直交する単位ベクトルを1つ見つけて返す。
+// for a given unit vector,
+// find some unit vector orthogonal for it.
 t_vec3	rt_coord_perpendicular_unit(const t_vec3 *u)
 {
 	t_vec3	ud;
@@ -32,7 +33,8 @@ t_vec3	rt_coord_perpendicular_unit(const t_vec3 *u)
 	return (mr_unit_vector(&dd));
 }
 
-// 与えられた単位ベクトル u と n について、 u を n のまわりに90度回したベクトルを返す。
+// for a given vector u and a unit vector n,
+// returns a vector that rotate u 90-degrees around n.
 t_vec3	rt_coord_turn_around_90(const t_vec3 *u, const t_vec3 *n)
 {
 	return (mr_vec3_add(

--- a/srcs/rt_diffuse.c
+++ b/srcs/rt_diffuse.c
@@ -6,7 +6,7 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/12/22 22:03:25 by rmatsuka          #+#    #+#             */
-/*   Updated: 2022/01/10 11:52:14 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/01/12 02:31:51 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,7 +25,8 @@ static double	intensity(
 				* mr_vec3_length_squared(&light_in))));
 }
 
-t_vec3	rt_diffuse(
+// color component by light diffusion.
+t_vec3	rt_color_diffuse(
 	const t_hit_record *rec,
 	const t_element *light,
 	const t_vec3 *light_color)

--- a/srcs/rt_equation.c
+++ b/srcs/rt_equation.c
@@ -3,17 +3,18 @@
 /*                                                        :::      ::::::::   */
 /*   rt_equation.c                                      :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: rmatsuka < rmatsuka@student.42tokyo.jp>    +#+  +:+       +#+        */
+/*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/12/25 17:01:33 by corvvs            #+#    #+#             */
-/*   Updated: 2022/01/06 09:08:12 by rmatsuka         ###   ########.fr       */
+/*   Updated: 2022/01/12 02:02:22 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minirt.h"
 #define EPS 1e-6
 
-// arg で定義される1次方程式 2b_half t + c = 0 を解き、答えの数(0, 1)を返す。
+// solve a given linear equation 2 * b_half * t + c = 0,
+// and returns the number of the equation.
 int	rt_solve_equation1(t_equation2 *arg)
 {
 	if (fabs(arg->b_half) < EPS)
@@ -26,7 +27,8 @@ int	rt_solve_equation1(t_equation2 *arg)
 	return (arg->solutions);
 }
 
-// arg で定義される2次方程式 at^2 + 2b_half t + c = 0 を解き、答えの数(0, 1, 2)を返す。
+// solve a given quadratic equation a * t^2 + 2 * b_half * t + c = 0,
+// and returns the number of the equation.
 int	rt_solve_equation2(t_equation2 *arg)
 {
 	const double	discriminant = arg->b_half * arg->b_half - arg->a * arg->c;

--- a/srcs/rt_fmath.c
+++ b/srcs/rt_fmath.c
@@ -1,0 +1,29 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   rt_fmath.c                                         :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/01/12 03:52:38 by corvvs            #+#    #+#             */
+/*   Updated: 2022/01/12 04:19:37 by corvvs           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minirt.h"
+
+double	rt_fmod(double x, double y)
+{
+	if (x >= 0)
+		return (fmod(x, y));
+	else
+		return (y - fmod(-x, y));
+}
+
+double	rt_floor(double x)
+{
+	if (x >= 0)
+		return (floor(x));
+	else
+		return (-ceil(-x));
+}

--- a/srcs/rt_is_shadow.c
+++ b/srcs/rt_is_shadow.c
@@ -6,7 +6,7 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/12/09 16:56:38 by rmatsuka          #+#    #+#             */
-/*   Updated: 2022/01/09 20:36:18 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/01/12 01:59:13 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,15 +14,15 @@
 #define EPS 1e-5
 #define EPS2 1e-2
 
-// 光源とカメラが反射面を挟んで逆側にいる時反射は起きない
+// reflection will only happen when
+// both light and camera are in same side to the surface
 static bool	is_reflective_part(
 	const t_hit_record *rec,
 	const t_element *light,
 	const t_ray *ray)
 {
 	const t_vec3	light_in = mr_vec3_sub(rec->p, light->position);
-	const double	cos_light = mr_vec3_dot(
-						light_in, rec->normal);
+	const double	cos_light = mr_vec3_dot(light_in, rec->normal);
 	const double	cos_ray = mr_vec3_dot(
 						ray->direction, rec->normal);
 	const bool		is_reflective = ((cos_light > 0 && cos_ray > 0) \
@@ -30,9 +30,13 @@ static bool	is_reflective_part(
 	t_vec3			pc;
 
 	if (!is_reflective)
+	{
 		return (false);
+	}
 	if (light->etype != RD_ET_SPOTLIGHT)
+	{
 		return (true);
+	}
 	pc = mr_vec3_sub(rec->p, light->position);
 	mr_normalize_comp(&pc);
 	return (mr_vec3_dot(pc, light->direction) >= cos(light->fov));
@@ -62,11 +66,7 @@ static bool	is_obj_closer_than_light(
 	return (false);
 }
 
-// v = 交点から光源へのベクトル
-// incident = 出射ベクトル
-// shadow_ray.originを入射方向に少しずらす
-// 物体との距離が光源よりも近い場合は影
-bool	rt_is_shadow(
+bool	rt_is_shadowed_from(
 	const t_hit_record *actual,
 	const t_element *light,
 	t_scene *scene,

--- a/srcs/rt_reflection.c
+++ b/srcs/rt_reflection.c
@@ -6,7 +6,7 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/01/08 11:10:43 by corvvs            #+#    #+#             */
-/*   Updated: 2022/01/08 16:47:44 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/01/12 02:31:07 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,12 +22,12 @@ static t_vec3	light_proc(
 	t_vec3	base_color;
 
 	mr_vec3_init(&base_color, 0, 0, 0);
-	if (actual->hit && !rt_is_shadow(actual, light, scene, r))
+	if (actual->hit && !rt_is_shadowed_from(actual, light, scene, r))
 	{
 		mr_vec3_add_comp(&base_color,
-			rt_diffuse(actual, light, &light->color));
+			rt_color_diffuse(actual, light, &light->color));
 		mr_vec3_add_comp(&base_color,
-			rt_specular(actual, &light->position, &light->color, r));
+			rt_color_specular(actual, &light->position, &light->color, r));
 	}
 	return (base_color);
 }
@@ -44,7 +44,7 @@ t_vec3	rt_reflect_ray(
 
 	rt_set_tangent_space(actual);
 	actual_0 = *actual;
-	base_color = rt_ambient(scene->ambient->ratio,
+	base_color = rt_color_ambient(scene->ambient->ratio,
 			&scene->ambient->color, &actual_0.color);
 	i = 0;
 	while (i < scene->n_spotlights)

--- a/srcs/rt_specular.c
+++ b/srcs/rt_specular.c
@@ -6,7 +6,7 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/12/22 22:54:35 by rmatsuka          #+#    #+#             */
-/*   Updated: 2022/01/10 11:50:57 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/01/12 02:32:03 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,10 +15,8 @@
 #define INTENSITY 30.0
 #define GLOSS 30.0
 
-// ray_inverse = レイの方向の逆向きの方向ベクトル(正規化済み)
-// light_out = 反射面から光源を見る方向ベクトル
-// reflect_of_light = light_out に対応する反射光のベクトル
-t_vec3	rt_specular(
+// color component by specular reflection.
+t_vec3	rt_color_specular(
 	const t_hit_record *rec,
 	const t_vec3 *light,
 	const t_vec3 *light_color,

--- a/srcs/rt_tangent.c
+++ b/srcs/rt_tangent.c
@@ -29,7 +29,7 @@ static const t_object_tangent_setter	g_tangent_setters[] = {
  *  cylinder : 10.0
  *  sphere   : 10.0
  */
-static t_vec3	checker_texture(const t_hit_record *rec)
+static t_vec3	rt_color_checker(const t_hit_record *rec)
 {
 	const double	u = rec->u;
 	const double	v = rec->v;
@@ -61,7 +61,7 @@ void	rt_set_tangent_space(
 	if (rec->element.tex_el && rec->element.tex_el->etype == RD_ET_TEXTURE)
 		rec->color = rt_color_texture(rec->u, rec->v, rec->element.tex_el);
 	else if (rec->element.tex_el && rec->element.tex_el->etype == RD_ET_CHECKER)
-		rec->color = checker_texture(rec);
+		rec->color = rt_color_checker(rec);
 	else
 		rec->color = rec->element.color;
 }

--- a/srcs/rt_tangent.c
+++ b/srcs/rt_tangent.c
@@ -6,7 +6,7 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/01/02 13:52:57 by corvvs            #+#    #+#             */
-/*   Updated: 2022/01/12 02:56:33 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/01/12 04:20:15 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,7 +35,7 @@ static t_vec3	rt_color_checker(const t_hit_record *rec)
 	const double	v = rec->v;
 	const t_element	*el = rec->element.tex_el;
 	const int		sines = \
-			(int)(floor(el->freq_u * u) + floor(el->freq_v * v));
+			(int)(rt_floor(el->freq_u * u * 2) + rt_floor(el->freq_v * v * 2));
 
 	if (sines % 2 == 0)
 	{

--- a/srcs/rt_tangent.c
+++ b/srcs/rt_tangent.c
@@ -6,7 +6,7 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/01/02 13:52:57 by corvvs            #+#    #+#             */
-/*   Updated: 2022/01/08 15:56:07 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/01/12 02:56:33 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,14 +47,6 @@ static t_vec3	checker_texture(const t_hit_record *rec)
 	}
 }
 
-// 法線ベクトル(rec->normal)
-// バンプマップがある場合はそれをみる。
-// ない場合は(0,0,1)を接空間から通常空間に逆変換する。
-
-// 色ベクトル(rec->color)
-// テクスチャマップがある場合はそれをみる。
-// チェッカーを使う場合はチェッカーに従って計算。
-// どちらでもない場合はelementの色を使う。
 void	rt_set_tangent_space(
 	t_hit_record *rec
 )
@@ -67,14 +59,15 @@ void	rt_set_tangent_space(
 		rec->normal = (t_vec3){0, 0, 1};
 	rec->normal = rt_vec_tangent_to_global(rec, &rec->normal);
 	if (rec->element.tex_el && rec->element.tex_el->etype == RD_ET_TEXTURE)
-		rec->color = rt_element_color(rec->u, rec->v, rec->element.tex_el);
+		rec->color = rt_color_texture(rec->u, rec->v, rec->element.tex_el);
 	else if (rec->element.tex_el && rec->element.tex_el->etype == RD_ET_CHECKER)
 		rec->color = checker_texture(rec);
 	else
 		rec->color = rec->element.color;
 }
 
-// 接空間上のベクトルを通常空間に変換する
+// transform a vector `vtangent` on tangent space
+// into global space.
 t_vec3	rt_vec_tangent_to_global(
 	t_hit_record *rec,
 	const t_vec3 *vtangent

--- a/srcs/rt_texture_cone.c
+++ b/srcs/rt_texture_cone.c
@@ -6,7 +6,7 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/12/26 23:37:49 by corvvs            #+#    #+#             */
-/*   Updated: 2022/01/08 15:31:12 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/01/12 04:21:53 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,7 +20,7 @@ static void	set_tangent_coordinate_cone(t_hit_record *rec)
 	const double	dx = mr_vec3_dot(pc, u1);
 	const double	dz = mr_vec3_dot(pc, u2);
 
-	rec->u = (1 - atan2(dz, dx)) / (2 * M_PI) - 0.5;
+	rec->u = -atan2(dz, dx) / (2 * M_PI);
 	rec->v = mr_vec3_length(&pc);
 }
 

--- a/srcs/rt_texture_cylinder.c
+++ b/srcs/rt_texture_cylinder.c
@@ -6,7 +6,7 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/12/21 13:41:07 by rmatsuka          #+#    #+#             */
-/*   Updated: 2022/01/08 15:32:33 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/01/12 04:27:27 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,10 +19,7 @@ static void	set_tangent_coordinate_cylinder(t_hit_record *rec)
 	const t_vec3	w0 = rt_coord_perpendicular_unit(&v0);
 	const t_vec3	u0 = rt_coord_turn_around_90(&w0, &v0);
 
-	rec->u = 1 - (atan2(
-				mr_vec3_dot(pc, w0),
-				mr_vec3_dot(pc, u0)
-				) / (2 * M_PI) - 0.5);
+	rec->u = -atan2(mr_vec3_dot(pc, w0), mr_vec3_dot(pc, u0)) / (2 * M_PI);
 	rec->v = -mr_vec3_dot(pc, v0);
 }
 

--- a/srcs/rt_texture_paraboloid.c
+++ b/srcs/rt_texture_paraboloid.c
@@ -6,7 +6,7 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/12/21 13:41:07 by rmatsuka          #+#    #+#             */
-/*   Updated: 2022/01/08 15:33:38 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/01/12 04:27:48 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,10 +20,7 @@ static double	tangent_u(
 	const t_vec3	w0 = rt_coord_perpendicular_unit(&el->direction);
 	const t_vec3	u0 = rt_coord_turn_around_90(&w0, &el->direction);
 
-	return (1 - (atan2(
-				mr_vec3_dot(*pc, w0),
-				mr_vec3_dot(*pc, u0)
-			) / (2 * M_PI) - 0.5));
+	return (-atan2(mr_vec3_dot(*pc, w0), mr_vec3_dot(*pc, u0)) / (2 * M_PI));
 }
 
 static double	tangent_v(

--- a/srcs/rt_texture_sphere.c
+++ b/srcs/rt_texture_sphere.c
@@ -6,7 +6,7 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/12/21 13:39:11 by rmatsuka          #+#    #+#             */
-/*   Updated: 2022/01/08 15:34:00 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/01/12 04:21:46 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,9 +16,8 @@ static void	set_tangent_coordinate_sphere(t_hit_record *rec)
 {
 	const t_vec3	*pos = &rec->element.position;
 
-	rec->u = 1 - (
-			atan2(rec->p.x - pos->x, rec->p.z - pos->z) / (2 * M_PI) - 0.5);
-	rec->v = acos((rec->p.y - pos->y) / rec->element.radius) / (M_PI);
+	rec->u = -atan2(rec->p.x - pos->x, rec->p.z - pos->z) / (2 * M_PI);
+	rec->v = acos((rec->p.y - pos->y) / rec->element.radius) / M_PI;
 }
 
 void	rt_set_tangent_sphere(


### PR DESCRIPTION
### チェック用RTファイル

```
A  1.0    100,100,200
L  -10,0,10  1.0  200,200,200
C  0,10,0 0,-1,0 90

sp 0,0,0 10 100,100,100
ch 3 1 255,0,0 0,255,0
```

### before

![image](https://user-images.githubusercontent.com/10496148/149011278-ead3eb6a-3cca-47ee-a8d6-3c923f60bef6.png)

### after

![image](https://user-images.githubusercontent.com/10496148/149011298-3cc4af45-7213-4192-bc74-dc5886632761.png)
