### PR TITLE
Linux VM 対応

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME		:=	miniRT
 CC			:=	gcc
-CFLAGS		=	-Werror -Wall -Wextra $(INC) -g -fsanitize=address
+CFLAGS		=	-Werror -Wall -Wextra $(INC) -g
 INC			=	-I$(X11) -I$(MLX) -I$(LIBFT) -Iincludes -Icommon -Ird
 X11			:=	/usr/X11/include
 LIBFT		:=	libft

--- a/libft/ft_strrchr.c
+++ b/libft/ft_strrchr.c
@@ -17,7 +17,7 @@ char	*ft_strrchr(const char *s, int c)
 	size_t	i;
 
 	i = ft_strlen((char *)s);
-	while (i >= 0)
+	while (1)
 	{
 		if (s[i] == (char)c)
 			return ((char *)s + i);

--- a/rd/Makefile
+++ b/rd/Makefile
@@ -3,7 +3,7 @@ MLX			:=	../minilibx-linux
 X11			:=	/usr/X11/include
 INC			:=	-I$(X11) -I$(MLX) -I../includes -I../common -I../libft
 LIBS		:=	-L../libft -L$(MLX) -L/$(X11)/../lib -lXext -lX11 -lm
-CFLAGS		:=	-Wall -Wextra -Werror -g -fsanitize=address $(INC)
+CFLAGS		:=	-Wall -Wextra -Werror -g $(INC)
 NAME		:=	libread.a
 SRCS		:=	rd_file.c \
 				rd_error.c \

--- a/srcs/mr_error.c
+++ b/srcs/mr_error.c
@@ -21,10 +21,13 @@ void	mr_bailout(t_info *info, const char *error)
 		mr_destroy_image_files(info);
 		if (info->scene)
 			rd_destroy_scene(info->scene);
+		if (info->mlx && info->img.img)
+		    mlx_destroy_image(info->mlx, info->img.img);
 		if (info->mlx && info->win)
 			mlx_destroy_window(info->mlx, info->win);
 		if (info->mlx)
 			mlx_destroy_display(info->mlx);
+		free(info->mlx);
 	}
 	exit(1);
 }

--- a/srcs/mr_error.c
+++ b/srcs/mr_error.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   mr_error.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: rmatsuka < rmatsuka@student.42tokyo.jp>    +#+  +:+       +#+        */
+/*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/01/11 18:04:00 by corvvs            #+#    #+#             */
-/*   Updated: 2022/01/12 16:01:53 by rmatsuka         ###   ########.fr       */
+/*   Updated: 2022/01/13 16:46:46 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,7 +22,7 @@ void	mr_bailout(t_info *info, const char *error)
 		if (info->scene)
 			rd_destroy_scene(info->scene);
 		if (info->mlx && info->img.img)
-		    mlx_destroy_image(info->mlx, info->img.img);
+			mlx_destroy_image(info->mlx, info->img.img);
 		if (info->mlx && info->win)
 			mlx_destroy_window(info->mlx, info->win);
 		if (info->mlx)

--- a/srcs/mr_mlx_utils.c
+++ b/srcs/mr_mlx_utils.c
@@ -45,8 +45,15 @@ int	mr_exit_window(t_info *info)
 {
 	mr_destroy_image_files(info);
 	rd_destroy_scene(info->scene);
+	if (info->mlx && info->img.img)
+	    mlx_destroy_image(info->mlx, info->img.img);
+	if (info->mlx && info->win)
+	  mlx_destroy_window(info->mlx, info->win);
+	if (info->mlx)
+	    mlx_destroy_display(info->mlx);
 	mlx_destroy_window(info->mlx, info->win);
 	mlx_destroy_display(info->mlx);
+	free(info->mlx);
 	exit(0);
 	return (0);
 }

--- a/srcs/mr_mlx_utils.c
+++ b/srcs/mr_mlx_utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   mr_mlx_utils.c                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: rmatsuka < rmatsuka@student.42tokyo.jp>    +#+  +:+       +#+        */
+/*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/01/04 23:43:35 by rmatsuka          #+#    #+#             */
-/*   Updated: 2022/01/12 13:48:09 by rmatsuka         ###   ########.fr       */
+/*   Updated: 2022/01/13 16:45:57 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -46,13 +46,11 @@ int	mr_exit_window(t_info *info)
 	mr_destroy_image_files(info);
 	rd_destroy_scene(info->scene);
 	if (info->mlx && info->img.img)
-	    mlx_destroy_image(info->mlx, info->img.img);
+		mlx_destroy_image(info->mlx, info->img.img);
 	if (info->mlx && info->win)
-	  mlx_destroy_window(info->mlx, info->win);
+		mlx_destroy_window(info->mlx, info->win);
 	if (info->mlx)
-	    mlx_destroy_display(info->mlx);
-	mlx_destroy_window(info->mlx, info->win);
-	mlx_destroy_display(info->mlx);
+		mlx_destroy_display(info->mlx);
 	free(info->mlx);
 	exit(0);
 	return (0);


### PR DESCRIPTION
**Makefileは修正していません。まだ`libmlx_Darwin`を使います。**

`libmlx_Darwin` -> `libmlx` に書き換えたうえで42VMでチェックし、以下の修正を実施

- `ft_strrchr`がVMでコンパイルできなかったので、修正
  - miniRTでは使っていないので、動作には影響しない
- mlx破壊処理でstill reachableがあったので、対応